### PR TITLE
feat: Create a stall delay penalty clear method

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1567,6 +1567,8 @@ class Hls implements HlsEventEmitter {
     get capLevelToPlayerSize(): boolean;
     // Warning: (ae-setter-with-docs) The doc comment for the property "capLevelToPlayerSize" must appear on the getter, not the setter.
     set capLevelToPlayerSize(shouldStartCapping: boolean);
+    // (undocumented)
+    clearStallLatencyPenalty(): void;
     readonly config: HlsConfig;
     // (undocumented)
     createController(ControllerClass: any, components: any): any;

--- a/package.json
+++ b/package.json
@@ -129,5 +129,6 @@
     "typescript": "5.3.3",
     "url-toolkit": "2.2.5",
     "wrangler": "3.22.4"
-  }
+  },
+  "version": "1.5.15"
 }

--- a/src/controller/latency-controller.ts
+++ b/src/controller/latency-controller.ts
@@ -129,6 +129,10 @@ export default class LatencyController implements ComponentAPI {
     this.hls = this.timeupdateHandler = null;
   }
 
+  public clearStallLatencyPenalty(): void {
+    this.stallCount = 0;
+  }
+
   private registerListeners() {
     this.hls.on(Events.MEDIA_ATTACHED, this.onMediaAttached, this);
     this.hls.on(Events.MEDIA_DETACHING, this.onMediaDetaching, this);

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -970,6 +970,10 @@ export default class Hls implements HlsEventEmitter {
   get forceStartLoad(): boolean {
     return this.streamController.forceStartLoad;
   }
+
+  public clearStallLatencyPenalty(): void {
+    this.latencyController.clearStallLatencyPenalty();
+  }
 }
 
 export type {


### PR DESCRIPTION
hls.js 내부적으로 `BUFFER_STALLED_ERROR` 발생 횟수만큼 `targetLatency`에 추가 latency로 패널티를 주고있음.

- 단, 패널티는 m3u8 #EXT-X-TARGETDURATION(세그먼트 최대 길이)를 초과할 수 없음.

플레이어 저지연 모드 활성화마다 `targetLatency`를 초기화해야 하는데, 이때 패널티가 초기화되지 않는 문제가 발생함.

- hls.js v1.6.0 부터 `setTargetLatency` 메서드를 제공하여 이를 사용하면 됨.
 
따라서 현재 사용 중인 v1.5.15 에서 패널티 latency를 초기화하는 `clearStallLatencyPenalty` 메서드를 생성함.