### PR TITLE
feat: BUFFER_STALLED_ERROR 로 인한 지연 패널티 비활성화

### DIFF
--- a/src/controller/latency-controller.ts
+++ b/src/controller/latency-controller.ts
@@ -65,10 +65,7 @@ export default class LatencyController implements ComponentAPI {
     const liveSyncOnStallIncrease = 1.0;
     return (
       targetLatency +
-      Math.min(
-        this.stallCount * liveSyncOnStallIncrease,
-        maxLiveSyncOnStallIncrease,
-      )
+      Math.min(liveSyncOnStallIncrease, maxLiveSyncOnStallIncrease)
     );
   }
 


### PR DESCRIPTION
hls.js 내부적으로 `BUFFER_STALLED_ERROR` 발생 횟수만큼 `targetLatency`에 추가 latency로 패널티를 주고있음.

- 단, 패널티는 m3u8 #EXT-X-TARGETDURATION(세그먼트 최대 길이)를 초과할 수 없음.

버퍼링 다수 발생시 부여된 지연 패널티로 인해 설정한 `targetLatency`가 변경되는 것을 막고자 지연 패널티를 비활성화 함.